### PR TITLE
Fix build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
-/build
 /SFML
 /PROGRAM
+
+# build files
+/build
+**/cmake-build-debug
+**/CMakeCache.txt
+**/cmake_install.cmake
+**/install_manifest.txt
+**/CMakeFiles/
+**/CTestTestfile.cmake
+**/Makefile
+**/*.cbp
+**/CMakeScripts
+**/compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,4 +12,9 @@ link_directories(SFML/lib)
 
 add_executable(SpaceCombat ${SOURCES})
 
-target_link_libraries(SpaceCombat sfml-main sfml-system sfml-window sfml-graphics)
+
+if(WIN32)
+    target_link_libraries(SpaceCombat sfml-main sfml-system sfml-window sfml-graphics)
+else()
+    target_link_libraries(SpaceCombat sfml-system sfml-window sfml-graphics)
+endif()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # Space-Combat-Game
+
+## Dependences
+- [SFML](https://www.sfml-dev.org/download/sfml/2.5.1/) Place builded in Space-Combat-Game/SFML/


### PR DESCRIPTION
- Fix build error on linux
- Add build files to gitignore
- Add note about dependences to README

Fixed error:
`/usr/bin/ld: cannot find -lsfml-main`
